### PR TITLE
Added support for setting ZK Quorum from flow. or global.

### DIFF
--- a/kafka.html
+++ b/kafka.html
@@ -115,9 +115,9 @@ Topic(s) = "topic1, topic2, topic3"
         },
         label: function() {
             if (this.zkquorumType === 'flow' && this.zkquorum.length < 19) {
-                return 'kafka flow.'+this.zkquorum;
+                return this.name||'kafka flow.'+this.zkquorum;
             } else if (this.zkquorumType === 'global' && this.zkquorum.length < 17) {
-                return 'kafka global.'+this.zkquorum;
+                return this.name||'kafka global.'+this.zkquorum;
             } else {
             return this.name||"kafka";
         }}

--- a/kafka.html
+++ b/kafka.html
@@ -13,7 +13,7 @@
             zkquorumType: {value:"str"},
 
             topics: {value:"", required: true},
-            debug: {value:"str"}
+            debug: {value:""}
         },
         inputs:1,
         outputs:0,

--- a/kafka.html
+++ b/kafka.html
@@ -3,26 +3,54 @@
         category: 'output',
         color: '#FFFFFF',
         defaults: {
-            zkquorum:{value:"", required: true},
+            zkquorum: {value:"", validate:function(v) {
+                var ptype = $("#node-input-zkquorumType").val() || this.zkquorumType;
+                if (ptype === 'flow' || ptype === 'global' ) {
+                    return /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]+)*/i.test(v);
+                }
+                return true;
+            }},
+            zkquorumType: {value:"str"},
+
             topics: {value:"", required: true},
-            debug: {value:""}
+            debug: {value:"str"}
         },
         inputs:1,
         outputs:0,
         icon: "kafka.png",
         align: "right",
+        oneditprepare: function() {
+            if (this.zkquorumType == null) {
+                if (this.zkquorum == "") {
+                    this.zkquorumType = "str";
+                }
+            } else if (this.zkquorumType === 'string' || this.zkquorumType === 'none') {
+                this.zkquorumType = "str";
+            }
+            $("#node-input-zkquorumType").val(this.zkquorumType);
+            $("#node-input-zkquorum").typedInput({
+                default: 'str',
+                typeField: $("#node-input-zkquorumType"),
+                types: ['flow', 'global', 'str']
+            });
+            },
         label: function() {
-            return this.name||"kafka";
-        }
+            if (this.zkquorumType === 'flow' && this.zkquorum.length < 19) {
+                return 'kafka flow.'+this.zkquorum;
+            } else if (this.zkquorumType === 'global' && this.zkquorum.length < 17) {
+                return 'kafka global.'+this.zkquorum;
+            } else {
+                return this.name||"kafka";
+            }}
     });
 </script>
 
 <script type="text/x-red" data-template-name="kafka">
-    <div class="form-row">
-        <label for="node-input-zkquorum"><i class="icon-tag"></i>ZK Quorum</label>
-        <input type="text" id="node-input-zkquorum" placeholder="ZK Quorum">
+     <div class="form-row">
+        <label for="node-input-payload"><i class="fa fa-envelope"></i>ZK Quorum</label>
+        <input type="text" id="node-input-zkquorum" style="width:70%">
+        <input type="hidden" id="node-input-zkquorumType">
     </div>
-
     <div class="form-row">
         <label for="node-input-topics"><i class="icon-tag"></i>Topic(s)</label>
         <input type="text" id="node-input-topics" placeholder="Topics">
@@ -53,7 +81,15 @@ Topic(s) = "topic1, topic2, topic3"
         category: 'input',
         color: '#FFFFFF',
         defaults: {
-            zkquorum:{value:"", required: true},
+            zkquorum: {value:"", required: true, validate:function(v) {
+                var ptype = $("#node-input-zkquorumType").val() || this.zkquorumType;
+                if (ptype === 'flow' || ptype === 'global' ) {
+                    return /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]+)*/i.test(v);
+                }
+                return true;
+            }},
+            zkquorumType: {value:"str"},
+
             topics: {value:"", required: true},
             groupId:{value:"", required: true},
             debug: {value:""},
@@ -62,18 +98,38 @@ Topic(s) = "topic1, topic2, topic3"
         inputs:0,
         outputs:1,
         icon: "kafka.png",
+        oneditprepare: function() {
+            if (this.zkquorumType == null) {
+                if (this.zkquorum == "") {
+                    this.zkquorumType = "str";
+                }
+            } else if (this.zkquorumType === 'string' || this.zkquorumType === 'none') {
+                this.zkquorumType = "str";
+            }
+            $("#node-input-zkquorumType").val(this.zkquorumType);
+            $("#node-input-zkquorum").typedInput({
+                default: 'str',
+                typeField: $("#node-input-zkquorumType"),
+                types: ['flow', 'global', 'str']
+            });
+        },
         label: function() {
+            if (this.zkquorumType === 'flow' && this.zkquorum.length < 19) {
+                return 'kafka flow.'+this.zkquorum;
+            } else if (this.zkquorumType === 'global' && this.zkquorum.length < 17) {
+                return 'kafka global.'+this.zkquorum;
+            } else {
             return this.name||"kafka";
-        }
+        }}
     });
 </script>
 
 <script type="text/x-red" data-template-name="kafka in">
-    <div class="form-row">
-        <label for="node-input-zkquorum"><i class="icon-tag"></i>ZK Quorum</label>
-        <input type="text" id="node-input-zkquorum" placeholder="ZK Quorum">
+     <div class="form-row">
+        <label for="node-input-payload"><i class="fa fa-envelope"></i>ZK Quorum</label>
+        <input type="text" id="node-input-zkquorum" style="width:70%">
+        <input type="hidden" id="node-input-zkquorumType">
     </div>
-
     <div class="form-row">
         <label for="node-input-topics"><i class="icon-tag"></i>Topic(s)</label>
         <input type="text" id="node-input-topics" placeholder="Topic">

--- a/kafka.js
+++ b/kafka.js
@@ -11,7 +11,16 @@ module.exports = function(RED) {
     function kafkaNode(config) {
         RED.nodes.createNode(this,config);
         var topic = config.topic;
-        var clusterZookeeper = config.zkquorum;
+        var clusterZookeeper = "nothin yet";
+        var zkquorum = config.zkquorum;
+        var zkquorumType = config.zkquorumType;
+        if (zkquorumType == 'str'){
+            clusterZookeeper = zkquorum
+        }
+        if (zkquorumType == 'global' || zkquorumType == 'flow' ){
+            clusterZookeeper = RED.util.evaluateNodeProperty(zkquorum,zkquorumType,this)
+            console.log(clusterZookeeper)
+        }
         var debug = (config.debug == "debug");
         var node = this;
         var kafka = require('kafka-node');
@@ -70,7 +79,16 @@ module.exports = function(RED) {
         var HighLevelConsumer = kafka.HighLevelConsumer;
         var Client = kafka.Client;
         var topics = String(config.topics);
-        var clusterZookeeper = config.zkquorum;
+        var clusterZookeeper = 'nothin yet';
+        var zkquorum = config.zkquorum;
+        var zkquorumType = config.zkquorumType;
+        if (zkquorumType == 'str'){
+            clusterZookeeper = zkquorum
+        }
+        if (zkquorumType == 'global' || zkquorumType == 'flow' ) {
+            clusterZookeeper = RED.util.evaluateNodeProperty(zkquorum, zkquorumType,this)
+            console.log(clusterZookeeper)
+        }
         var groupId = config.groupId;
         var debug = (config.debug == "debug");
         var client = new Client(clusterZookeeper);


### PR DESCRIPTION
Added this to allow dynamic retargeting of Kafka nodes at startup and runtime.  We use this to support dynamic cloning and installation of flows to different clusters.
Note that global/flow states set in settings.js will be used on initial deploy, since the existing Kafka nodes in the flows will instantiate before any inject/startup or other "in flow" initialization.  If you dynamically change the flow or global variable and want to update instantiated Kafka nodes, then redeploy.